### PR TITLE
Fix: Axes have negative durability after breaking large trees

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>xyz.ahosall.treecapitator</groupId>
     <artifactId>ahosall-tree-capitator</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/xyz/ahosall/treecapitator/Main.java
+++ b/src/main/java/xyz/ahosall/treecapitator/Main.java
@@ -7,7 +7,7 @@ import xyz.ahosall.treecapitator.listeners.TreeCapitatorListener;
 public class Main extends JavaPlugin {
     @Override
     public void onEnable() {
-        getLogger().info("Está pronto para ser utilizado!");
+        getLogger().info("Activated successfully!");
 
         // Register plugin events
         getServer()
@@ -17,6 +17,6 @@ public class Main extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        getLogger().info("Desativado com sucesso...");
+        getLogger().info("Successfully deactivated...");
     }
 }

--- a/src/main/java/xyz/ahosall/treecapitator/listeners/TreeCapitatorListener.java
+++ b/src/main/java/xyz/ahosall/treecapitator/listeners/TreeCapitatorListener.java
@@ -66,7 +66,6 @@ public class TreeCapitatorListener implements Listener {
 
     for (Block adjacentBlock : adjacentBlocks) {
       int toolDurability = getDurability(tool);
-      player.sendMessage("Durabilidade do item: " + tool.getType().toString() + " é de " + toolDurability);
 
       if (isWood(adjacentBlock.getType())) {
         if (toolDurability == 0) {

--- a/src/main/java/xyz/ahosall/treecapitator/listeners/TreeCapitatorListener.java
+++ b/src/main/java/xyz/ahosall/treecapitator/listeners/TreeCapitatorListener.java
@@ -65,8 +65,17 @@ public class TreeCapitatorListener implements Listener {
     };
 
     for (Block adjacentBlock : adjacentBlocks) {
+      int toolDurability = getDurability(tool);
+      player.sendMessage("Durabilidade do item: " + tool.getType().toString() + " é de " + toolDurability);
+
       if (isWood(adjacentBlock.getType())) {
-        adjacentBlock.getWorld().playSound(player.getLocation(), Sound.BLOCK_WOOD_BREAK, 40, 1);
+        if (toolDurability == 0) {
+          player.getInventory().setItemInMainHand(null);
+          adjacentBlock.getWorld().playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1.0f, 1.0f);
+          break;
+        }
+
+        adjacentBlock.getWorld().playSound(player.getLocation(), Sound.BLOCK_WOOD_BREAK, 1.0f, 1.0f);
         adjacentBlock.getWorld().dropItemNaturally(adjacentBlock.getLocation(), new ItemStack(adjacentBlock.getType()));
         adjacentBlock.setType(Material.AIR);
 
@@ -78,6 +87,18 @@ public class TreeCapitatorListener implements Listener {
 
   private boolean isWood(Material material) {
     return material.toString().endsWith("_LOG") || material.toString().endsWith("_STEM");
+  }
+
+  private Integer getDurability(ItemStack tool) {
+    if (tool != null && tool.getItemMeta() instanceof Damageable) {
+      Damageable damageable = (Damageable) tool.getItemMeta();
+      int damage = damageable.getDamage();
+      int durability = tool.getType().getMaxDurability() - damage;
+
+      return durability;
+    }
+
+    return null;
   }
 
   private void updateDurability(ItemStack tool) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,4 +1,4 @@
 name: AhosallTreeCapitator
 main: xyz.ahosall.treecapitator.Main
-version: 1.0
+version: 1.0.1
 api-version: 1.19


### PR DESCRIPTION
## Description  
This PR fixes the issue where axes could have negative durability after breaking adjacent wooden blocks (such as in large trees). Previously, each block would subtract one from the durability, leading to negative values if enough blocks were broken. Now, the tool's durability is properly checked, and the axe breaks when its durability reaches zero.

## Related Issue  
Fixes #123 (Axes have negative durability)

## Steps to Reproduce (Before Fix)
1. Equip any axe (stone, iron, diamond, etc.).
2. Find and break a large tree with multiple adjacent blocks.
3. Notice that the durability becomes negative after breaking enough blocks.

## Expected Behavior  
Once the axe's durability reaches zero, it should break, and no further blocks should be broken by the axe.

## Current Behavior  
The durability goes into negative values, and the axe only breaks after being used again once it has negative durability.

## Fix Details  
- Added a method `getDurability` to check the current durability of the tool.
- In the block-breaking loop (`TreeCapitatorListener.java`), the durability is now checked before each block is broken.
- If the tool has zero durability, the item is removed from the player's inventory, the item break sound is played, and the loop stops to prevent further damage to adjacent blocks.

## Environment
- Minecraft Version: 1.19.4
- Mod Version: v1.0 SNAPSHOT

## Screenshots (Before Fix)  
![stone-axe-hud-item](https://media.discordapp.net/attachments/1256274822338580542/1297061612141809715/image.png?ex=67148e42&is=67133cc2&hm=e22d243a2d6c31dcedbd666179155e62cfb00edce630c5fac9160ba2da852871&=&format=webp&quality=lossless&width=69&height=42)  
![stone-axe-durability-negative](https://media.discordapp.net/attachments/1256274822338580542/1297061700591292447/image.png?ex=67148e57&is=67133cd7&hm=6a8199052f439e1f2dd72cdb723d17baa7afff690bcd85c1cfee39785fa188c4&=&format=webp&quality=lossless&width=289&height=165)  

## Additional Context  
- The error was identified in the loop that breaks adjacent blocks (`TreeCapitatorListener.java`, lines 67:5–76:6).  
- The fix ensures that once the axe's durability is depleted, it is removed from the player's inventory, the item break sound is played, and the loop stops to prevent breaking further blocks.

## Testing  
- Tested on Minecraft 1.19.4 with different types of axes (stone, iron, diamond) to ensure the axe breaks correctly when durability reaches zero and no negative values occur.
