### PR TITLE
add smart sapling planting

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ AhosallTreeCapitator is a simple and efficient plugin that automates the process
 
 - Compatible with all types of Minecraft axes and trees.
 - Players who only want to mine one block can use sneaking mode to disable the capping of entire trees.
+- Trees are replanted after cutting them above the first block of the tree, if you cut them on the first block the saplings will not be replanted.
 
 ## Compatibility
 

--- a/src/main/java/xyz/ahosall/treecapitator/listeners/TreeCapitatorListener.java
+++ b/src/main/java/xyz/ahosall/treecapitator/listeners/TreeCapitatorListener.java
@@ -76,7 +76,14 @@ public class TreeCapitatorListener implements Listener {
 
         adjacentBlock.getWorld().playSound(player.getLocation(), Sound.BLOCK_WOOD_BREAK, 1.0f, 1.0f);
         adjacentBlock.getWorld().dropItemNaturally(adjacentBlock.getLocation(), new ItemStack(adjacentBlock.getType()));
-        adjacentBlock.setType(Material.AIR);
+
+        Material blockMaterial = Material.AIR;
+        Boolean isDirt = adjacentBlock.getRelative(0, -1, 0).getType().equals(Material.DIRT);
+
+        if (isDirt)
+          blockMaterial = Material.getMaterial(adjacentBlock.getType().toString().replace("_LOG", "_SAPLING"));
+
+        adjacentBlock.setType(blockMaterial);
 
         updateDurability(tool);
         processConnectedWood(adjacentBlock, player, tool, processedBlocks);


### PR DESCRIPTION
## Description
This PR adds new features requested by players, this new feature replants the seedlings of trees that are cut down, in an intelligent way without compromising those who want to keep the plantations, and those who do not want to keep them.

## Related Issue
Close #3 (Self planting of tree saplings)

## How to use
- To use the new function, simply cut the trees.
- Cut above the first block of wood, and the sapling will be replanted.
- Cut at the first block of wood, and the sapling will not be replanted.

